### PR TITLE
Make Dotenv accessible to the react components

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+DB_HOST=localhost
+DB_USER=surfer  
+DB_PASS=surfer
+DB_NAME=surfbuddy
+DB_SSL=true if heroku
+DB_PORT=5432
+SG_KEY=51e978d6-a6fd-11e8-a9d2-0242ac130004-51e98344-a6fd-11e8-a9d2-0242ac130004
+REACT_APP_API_KEY=AIzaSyCuocPP6MC42bvb7_UMx-e1chuQbo8Eo_I

--- a/package-lock.json
+++ b/package-lock.json
@@ -2449,6 +2449,12 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
+    "dotenv": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-react": "6.23.0",
     "babel-preset-stage-0": "6.22.0",
     "css-loader": "0.26.1",
+    "dotenv": "^6.0.0",
     "eslint": "3.15.0",
     "eslint-plugin-react": "6.9.0",
     "node-sass": "4.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,18 @@
 var path = require('path');
 var webpack = require('webpack');
+const dotenv = require('dotenv');
+ 
+const env = dotenv.config().parsed;
+
+const envKeys = Object.keys(env).reduce((prev, next) => {
+  prev[`process.env.${next}`] = JSON.stringify(env[next]);
+  return prev;
+}, {});
 
 module.exports = {
+  plugins: [
+    new webpack.DefinePlugin(envKeys)
+  ],
   devtool: 'eval',
   entry: [
     'webpack-dev-server/client?http://localhost:3000',


### PR DESCRIPTION
This PR makes the `.env` file available to our React ecosystem.

The reason why this needs to happen is so that our components will eventually be able to receive their dependencies from our `.env`